### PR TITLE
Descriptor array as pointer array

### DIFF
--- a/src/execute_commands.cpp
+++ b/src/execute_commands.cpp
@@ -495,6 +495,7 @@ static bool run_spirv(command_execution_data& data, const shader_stage& stage, c
 	SPIRVSimulator::SimulationData inputs;
 	SPIRVSimulator::SimulationResults results;
 	std::deque<uint64_t> opaque_storage;
+	std::deque<std::vector<uint64_t>> pointer_array_storage;
 	std::vector<simulator_buffer_range> simulator_ranges;
 	std::unordered_map<const void*, simulator_buffer_range> range_lookup;
 	inputs.push_constants = data.push_constants.empty() ? nullptr : data.push_constants.data();
@@ -515,63 +516,157 @@ static bool run_spirv(command_execution_data& data, const shader_stage& stage, c
 	{
 		inputs.specialization_constant_offsets[v.constantID] = v.offset;
 	}
-	for (const auto& set_pair : data.descriptorsets)
+	for (const auto& set_pair : data.descriptor_sets)
 	{
 		auto& set_bindings = inputs.bindings[set_pair.first];
 		for (const auto& binding_pair : set_pair.second)
 		{
-			const buffer_access& access = binding_pair.second;
-			if (!access.buffer_data) continue;
-			const uint32_t buffer_index = access.buffer_data->index;
-			suballoc_location loc = data.device_data.allocator->find_buffer_memory(buffer_index);
-			assert(loc.mapped);
-			std::byte* base = (std::byte*)loc.mapped;
-			std::byte* binding_ptr = base + access.offset;
-			set_bindings[binding_pair.first] = binding_ptr;
-			const VkDeviceSize binding_size = (access.size != 0) ? access.size : (access.buffer_data->size - access.offset);
-			register_simulator_buffer_range(simulator_ranges, binding_ptr, binding_size, access.buffer_data, access.offset, set_pair.first, binding_pair.first);
-			// Provide real runtime-array length information to the SPIR-V simulator
-			if (binding_size > 0)
+			const command_execution_data::simulator_binding& binding = binding_pair.second;
+			VkDescriptorType descriptor_type = binding.descriptor_type;
+			if (descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM)
 			{
-				inputs.rt_array_lengths[simulator_pointer_bits(binding_ptr)][0] = static_cast<size_t>(binding_size);
+				if (!binding.buffers.empty() && binding.images.empty() && binding.opaques.empty()) descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+				else if (binding.buffers.empty() && !binding.images.empty() && binding.opaques.empty()) descriptor_type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+				else if (binding.buffers.empty() && binding.images.empty() && !binding.opaques.empty()) descriptor_type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
 			}
-			if ((access.buffer_data->usage2 & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+			if (binding.descriptor_buffer_backed)
 			{
-				inputs.descriptor_candidates[binding_ptr];
-			}
-		}
-	}
-	for (const auto& set_pair : data.imagesets)
-	{
-		auto& set_bindings = inputs.bindings[set_pair.first];
-		for (const auto& binding_pair : set_pair.second)
-		{
-			if (set_bindings.count(binding_pair.first) > 0) continue;
-			const image_access& access = binding_pair.second;
-			void* binding_ptr = nullptr;
-			if (access.image_data)
-			{
-				suballoc_location loc = data.device_data.allocator->find_image_memory(access.image_data->index);
+				if (binding.buffers.empty() || !binding.buffers[0].buffer_data) continue;
+				const buffer_access& access = binding.buffers[0];
+				const uint32_t buffer_index = access.buffer_data->index;
+				suballoc_location loc = data.device_data.allocator->find_buffer_memory(buffer_index);
 				assert(loc.mapped);
 				std::byte* base = (std::byte*)loc.mapped;
-				binding_ptr = base;
+				std::byte* binding_ptr = base + access.offset;
+				set_bindings[binding_pair.first] = binding_ptr;
+				const VkDeviceSize binding_size = (access.size != 0) ? access.size : (access.buffer_data->size - access.offset);
+				register_simulator_buffer_range(simulator_ranges, binding_ptr, binding_size, access.buffer_data, access.offset, set_pair.first, binding_pair.first);
+				if (binding_size > 0)
+				{
+					inputs.rt_array_lengths[simulator_pointer_bits(binding_ptr)][0] = static_cast<size_t>(binding_size);
+				}
+				if ((access.buffer_data->usage2 & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+				{
+					inputs.descriptor_candidates[binding_ptr];
+				}
+				continue;
 			}
-			else
+
+			switch (descriptor_type)
 			{
-				static uint64_t dummy_descriptor = 0;
-				binding_ptr = &dummy_descriptor;
+			case VK_DESCRIPTOR_TYPE_SAMPLER:
+			case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+			case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+			case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+			case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+				{
+					void* binding_ptr = nullptr;
+					for (auto it = binding.images.rbegin(); it != binding.images.rend(); ++it)
+					{
+						if (!it->image_data) continue;
+						suballoc_location loc = data.device_data.allocator->find_image_memory(it->image_data->index);
+						assert(loc.mapped);
+						binding_ptr = loc.mapped;
+						break;
+					}
+					if (!binding_ptr && !binding.images.empty())
+					{
+						static uint64_t dummy_descriptor = 0;
+						binding_ptr = &dummy_descriptor;
+					}
+					if (binding_ptr) set_bindings[binding_pair.first] = binding_ptr;
+				}
+				break;
+			case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+			case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+				{
+					for (auto it = binding.buffers.rbegin(); it != binding.buffers.rend(); ++it)
+					{
+						if (!it->buffer_data) continue;
+						suballoc_location loc = data.device_data.allocator->find_buffer_memory(it->buffer_data->index);
+						assert(loc.mapped);
+						std::byte* binding_ptr = (std::byte*)loc.mapped + it->offset;
+						const VkDeviceSize binding_size = (it->size != 0) ? it->size : (it->buffer_data->size - it->offset);
+						set_bindings[binding_pair.first] = binding_ptr;
+						register_simulator_buffer_range(simulator_ranges, binding_ptr, binding_size, it->buffer_data, it->offset, set_pair.first, binding_pair.first);
+						if (binding_size > 0)
+						{
+							inputs.rt_array_lengths[simulator_pointer_bits(binding_ptr)][0] = static_cast<size_t>(binding_size);
+						}
+						if ((it->buffer_data->usage2 & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+						{
+							inputs.descriptor_candidates[binding_ptr];
+						}
+						break;
+					}
+				}
+				break;
+			case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+			case VK_DESCRIPTOR_TYPE_TENSOR_ARM:
+				for (auto it = binding.opaques.rbegin(); it != binding.opaques.rend(); ++it)
+				{
+					if (*it == 0) continue;
+					opaque_storage.push_back(*it);
+					set_bindings[binding_pair.first] = &opaque_storage.back();
+					break;
+				}
+				break;
+			case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+			case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+			case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+			case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+				{
+					if (binding.buffers.empty()) continue;
+					if (binding.buffers.size() == 1 && binding.buffers[0].buffer_data)
+					{
+						const buffer_access& access = binding.buffers[0];
+						const uint32_t buffer_index = access.buffer_data->index;
+						suballoc_location loc = data.device_data.allocator->find_buffer_memory(buffer_index);
+						assert(loc.mapped);
+						std::byte* base = (std::byte*)loc.mapped;
+						std::byte* binding_ptr = base + access.offset;
+						const VkDeviceSize binding_size = (access.size != 0) ? access.size : (access.buffer_data->size - access.offset);
+						set_bindings[binding_pair.first] = binding_ptr;
+						register_simulator_buffer_range(simulator_ranges, binding_ptr, binding_size, access.buffer_data, access.offset, set_pair.first, binding_pair.first);
+						if (binding_size > 0)
+						{
+							inputs.rt_array_lengths[simulator_pointer_bits(binding_ptr)][0] = static_cast<size_t>(binding_size);
+						}
+						if ((access.buffer_data->usage2 & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+						{
+							inputs.descriptor_candidates[binding_ptr];
+						}
+						break;
+					}
+
+					pointer_array_storage.emplace_back(binding.buffers.size(), 0);
+					std::vector<uint64_t>& pointer_array = pointer_array_storage.back();
+					for (size_t i = 0; i < binding.buffers.size(); i++)
+					{
+						const buffer_access& access = binding.buffers[i];
+						if (!access.buffer_data) continue;
+						suballoc_location loc = data.device_data.allocator->find_buffer_memory(access.buffer_data->index);
+						assert(loc.mapped);
+						std::byte* binding_ptr = (std::byte*)loc.mapped + access.offset;
+						const VkDeviceSize binding_size = (access.size != 0) ? access.size : (access.buffer_data->size - access.offset);
+						pointer_array[i] = simulator_pointer_bits(binding_ptr);
+						register_simulator_buffer_range(simulator_ranges, binding_ptr, binding_size, access.buffer_data, access.offset, set_pair.first, binding_pair.first);
+						if (binding_size > 0)
+						{
+							inputs.rt_array_lengths[simulator_pointer_bits(binding_ptr)][0] = static_cast<size_t>(binding_size);
+						}
+						if ((access.buffer_data->usage2 & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+						{
+							inputs.descriptor_candidates[binding_ptr];
+						}
+					}
+					inputs.rt_array_lengths[simulator_pointer_bits(pointer_array.data())][0] = pointer_array.size();
+					set_bindings[binding_pair.first] = pointer_array.data();
+				}
+				break;
+			default:
+				break;
 			}
-			set_bindings[binding_pair.first] = binding_ptr;
-		}
-	}
-	for (const auto& set_pair : data.opaquesets)
-	{
-		auto& set_bindings = inputs.bindings[set_pair.first];
-		for (const auto& binding_pair : set_pair.second)
-		{
-			if (set_bindings.count(binding_pair.first) > 0) continue;
-			opaque_storage.push_back(binding_pair.second ? binding_pair.second : 1);
-			set_bindings[binding_pair.first] = &opaque_storage.back();
 		}
 	}
 
@@ -1039,40 +1134,102 @@ bool execute_commands(command_execution_data& data)
 		switch (c.id)
 		{
 		case VKCMDBINDDESCRIPTORSETS:
+			{
+			const trackedpipelinelayout* layout_data = nullptr;
+			if (c.data.bind_descriptorsets.layout != VK_NULL_HANDLE)
+			{
+				const uint32_t pipeline_layout_index = index_to_VkPipelineLayout.index(c.data.bind_descriptorsets.layout);
+				if (pipeline_layout_index != CONTAINER_INVALID_INDEX) layout_data = &VkPipelineLayout_index.at(pipeline_layout_index);
+			}
+			uint32_t dynamic_offset_index = 0;
 			for (uint32_t i = 0; i < c.data.bind_descriptorsets.descriptorSetCount; i++)
 			{
 				uint32_t set = c.data.bind_descriptorsets.firstSet + i;
 				auto& tds = VkDescriptorSet_index.at(c.data.bind_descriptorsets.pDescriptorSets[i]); // is index now
+				data.descriptor_sets[set].clear();
+				const trackeddescriptorsetlayout* set_layout_data = nullptr;
+				if (layout_data && set < layout_data->layout_indices.size())
+				{
+					const uint32_t set_layout_index = layout_data->layout_indices[set];
+					if (set_layout_index != CONTAINER_INVALID_INDEX) set_layout_data = &VkDescriptorSetLayout_index.at(set_layout_index);
+				}
 				for (const auto& pair : tds.bound_buffers)
 				{
-					data.descriptorsets[set][pair.first] = pair.second;
+					const uint32_t binding = descriptor_binding_slot_binding(pair.first);
+					const uint32_t array_index = descriptor_binding_slot_array_index(pair.first);
+					command_execution_data::simulator_binding& dst = data.descriptor_sets[set][binding];
+					if (set_layout_data)
+					{
+						auto type_it = set_layout_data->binding_types.find(binding);
+						if (type_it != set_layout_data->binding_types.end()) dst.descriptor_type = type_it->second;
+						auto count_it = set_layout_data->binding_counts.find(binding);
+						if (count_it != set_layout_data->binding_counts.end() && dst.buffers.size() < count_it->second) dst.buffers.resize(count_it->second);
+					}
+					if (dst.buffers.size() <= array_index) dst.buffers.resize(array_index + 1);
+					dst.buffers[array_index] = pair.second;
 				}
 				for (const auto& pair : tds.bound_images)
 				{
-					data.imagesets[set][pair.first] = pair.second;
+					const uint32_t binding = descriptor_binding_slot_binding(pair.first);
+					const uint32_t array_index = descriptor_binding_slot_array_index(pair.first);
+					command_execution_data::simulator_binding& dst = data.descriptor_sets[set][binding];
+					if (set_layout_data)
+					{
+						auto type_it = set_layout_data->binding_types.find(binding);
+						if (type_it != set_layout_data->binding_types.end()) dst.descriptor_type = type_it->second;
+						auto count_it = set_layout_data->binding_counts.find(binding);
+						if (count_it != set_layout_data->binding_counts.end() && dst.images.size() < count_it->second) dst.images.resize(count_it->second);
+					}
+					if (dst.images.size() <= array_index) dst.images.resize(array_index + 1);
+					dst.images[array_index] = pair.second;
 				}
 				for (const auto& pair : tds.bound_opaque_descriptors)
 				{
-					data.opaquesets[set][pair.first] = pair.second;
+					const uint32_t binding = descriptor_binding_slot_binding(pair.first);
+					const uint32_t array_index = descriptor_binding_slot_array_index(pair.first);
+					command_execution_data::simulator_binding& dst = data.descriptor_sets[set][binding];
+					if (set_layout_data)
+					{
+						auto type_it = set_layout_data->binding_types.find(binding);
+						if (type_it != set_layout_data->binding_types.end()) dst.descriptor_type = type_it->second;
+						auto count_it = set_layout_data->binding_counts.find(binding);
+						if (count_it != set_layout_data->binding_counts.end() && dst.opaques.size() < count_it->second) dst.opaques.resize(count_it->second);
+					}
+					if (dst.opaques.size() <= array_index) dst.opaques.resize(array_index + 1);
+					dst.opaques[array_index] = pair.second;
 				}
-				uint32_t binding = 0;
 				for (const auto& pair : tds.dynamic_buffers)
 				{
 					buffer_access access;
+					const uint32_t binding = descriptor_binding_slot_binding(pair.first);
+					const uint32_t array_index = descriptor_binding_slot_array_index(pair.first);
+					if (pair.second.buffer == VK_NULL_HANDLE) continue;
 					const uint32_t buffer_index = index_to_VkBuffer.index(pair.second.buffer);
 					auto& buffer_data = VkBuffer_index.at(buffer_index);
 					access.buffer_data = &buffer_data;
 					access.offset = pair.second.offset;
-					if (c.data.bind_descriptorsets.pDynamicOffsets) access.offset += c.data.bind_descriptorsets.pDynamicOffsets[binding];
+					if (c.data.bind_descriptorsets.pDynamicOffsets)
+					{
+						assert(c.data.bind_descriptorsets.dynamicOffsetCount > dynamic_offset_index);
+						access.offset += c.data.bind_descriptorsets.pDynamicOffsets[dynamic_offset_index];
+					}
 					access.size = pair.second.range;
 					if (access.size == VK_WHOLE_SIZE) access.size = buffer_data.size - access.offset;
-					data.descriptorsets[set][pair.first] = access;
-					binding++;
-					assert(!c.data.bind_descriptorsets.pDynamicOffsets || c.data.bind_descriptorsets.dynamicOffsetCount >= binding);
+					command_execution_data::simulator_binding& dst = data.descriptor_sets[set][binding];
+					dst.descriptor_type = set_layout_data ? set_layout_data->binding_types.at(binding) : VK_DESCRIPTOR_TYPE_MAX_ENUM;
+					if (set_layout_data)
+					{
+						auto count_it = set_layout_data->binding_counts.find(binding);
+						if (count_it != set_layout_data->binding_counts.end() && dst.buffers.size() < count_it->second) dst.buffers.resize(count_it->second);
+					}
+					if (dst.buffers.size() <= array_index) dst.buffers.resize(array_index + 1);
+					dst.buffers[array_index] = access;
+					dynamic_offset_index++;
 				}
 			}
 			free((void*)c.data.bind_descriptorsets.pDescriptorSets);
 			free((void*)c.data.bind_descriptorsets.pDynamicOffsets);
+			}
 			break;
 		case VKCMDBINDDESCRIPTORBUFFERSEXT:
 			descriptor_buffers.clear();
@@ -1120,11 +1277,17 @@ bool execute_commands(command_execution_data& data)
 						const VkDeviceSize binding_offset = offset_it != set_layout_data.offsets.end() ? offset_it->second : 0;
 						const VkDeviceSize descriptor_offset = descriptor_buffer.offset + set_offset + binding_offset;
 						if (descriptor_offset >= descriptor_buffer.buffer_data->size) continue;
-						data.descriptorsets[set][binding] = {
+						command_execution_data::simulator_binding& dst = data.descriptor_sets[set][binding];
+						dst.descriptor_type = binding_pair.second;
+						dst.descriptor_buffer_backed = true;
+						dst.buffers.clear();
+						dst.images.clear();
+						dst.opaques.clear();
+						dst.buffers.push_back({
 							.buffer_data = descriptor_buffer.buffer_data,
 							.offset = descriptor_offset,
 							.size = descriptor_buffer.buffer_data->size - descriptor_offset,
-						};
+						});
 						VkMarkingSubTypeARM subtype{};
 						subtype.descriptorType = binding_pair.second;
 						std::vector<discovered_buffer_marking> discovered_markings;

--- a/src/execute_commands.h
+++ b/src/execute_commands.h
@@ -6,12 +6,19 @@
 
 struct command_execution_data
 {
+	struct simulator_binding
+	{
+		VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+		bool descriptor_buffer_backed = false;
+		std::vector<buffer_access> buffers;
+		std::vector<image_access> images;
+		std::vector<uint64_t> opaques;
+	};
+
 	const trackeddevice& device_data;
 	const trackedcmdbuffer& cmdbuffer_data;
 	const address_remapper<trackedobject>& device_address_remapping;
-	std::unordered_map<uint32_t, std::unordered_map<uint32_t, buffer_access>> descriptorsets; // descriptorset binding : set internal binding point : buffer
-	std::unordered_map<uint32_t, std::unordered_map<uint32_t, image_access>> imagesets; // descriptorset binding : set internal binding point : image
-	std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint64_t>> opaquesets; // descriptorset binding : set internal binding point : opaque descriptor payload
+	std::unordered_map<uint32_t, std::unordered_map<uint32_t, simulator_binding>> descriptor_sets; // set -> binding -> logical binding contents
 	std::vector<std::byte> push_constants; // current state of the push constants
 	host_write_regions push_constant_sources;
 	std::list<address_rewrite>& global_output_rewrite_queue;

--- a/src/lavatube.h
+++ b/src/lavatube.h
@@ -942,16 +942,31 @@ struct trackedcmdbuffer_trace : trackedcmdbuffer
 
 struct buffer_access
 {
-	trackedbuffer* buffer_data;
-	VkDeviceSize offset;
-	VkDeviceSize size; // not sure if we need this
+	trackedbuffer* buffer_data = nullptr;
+	VkDeviceSize offset = 0;
+	VkDeviceSize size = 0; // not sure if we need this
 };
 
 struct image_access
 {
-	trackedimage* image_data;
-	VkImageLayout layout;
+	trackedimage* image_data = nullptr;
+	VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
 };
+
+static inline uint64_t descriptor_binding_slot(uint32_t binding, uint32_t array_index)
+{
+	return (uint64_t(binding) << 32) | array_index;
+}
+
+static inline uint32_t descriptor_binding_slot_binding(uint64_t slot)
+{
+	return uint32_t(slot >> 32);
+}
+
+static inline uint32_t descriptor_binding_slot_array_index(uint64_t slot)
+{
+	return uint32_t(slot);
+}
 
 struct trackeddescriptorsetlayout : trackable
 {
@@ -959,6 +974,7 @@ struct trackeddescriptorsetlayout : trackable
 	VkDeviceSize size = 0;
 	std::unordered_map<int, VkDeviceSize> offsets;
 	std::unordered_map<uint32_t, VkDescriptorType> binding_types;
+	std::unordered_map<uint32_t, uint32_t> binding_counts;
 };
 
 struct trackeddescriptorset : trackable
@@ -968,10 +984,10 @@ struct trackeddescriptorset : trackable
 	VkDescriptorPool pool = VK_NULL_HANDLE;
 
 	// postprocess only
-	std::unordered_map<uint32_t, buffer_access> bound_buffers; // binding point to buffer access
-	std::unordered_map<uint32_t, image_access> bound_images; // binding point to image access
-	std::unordered_map<uint32_t, uint64_t> bound_opaque_descriptors; // binding point to opaque descriptor payload
-	std::unordered_map<uint32_t, VkDescriptorBufferInfo> dynamic_buffers; // must be resolved on bind
+	std::map<uint64_t, buffer_access> bound_buffers; // binding<<32 | array index to buffer access
+	std::map<uint64_t, image_access> bound_images; // binding<<32 | array index to image access
+	std::map<uint64_t, uint64_t> bound_opaque_descriptors; // binding<<32 | array index to opaque descriptor payload
+	std::map<uint64_t, VkDescriptorBufferInfo> dynamic_buffers; // binding<<32 | array index, resolved on bind
 
 	void self_test() const
 	{

--- a/src/postprocess.cpp
+++ b/src/postprocess.cpp
@@ -58,8 +58,14 @@ static void handle_VkWriteDescriptorSets(uint32_t descriptorWriteCount, const Vk
 		case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
 			for (unsigned j = 0; j < pDescriptorWrites[i].descriptorCount; j++)
 			{
+				const uint64_t slot = descriptor_binding_slot(binding, pDescriptorWrites[i].dstArrayElement + j);
 				const VkDescriptorImageInfo& info = pDescriptorWrites[i].pImageInfo[j];
-				if (info.imageView == VK_NULL_HANDLE && info.sampler == VK_NULL_HANDLE) continue;
+				if (info.imageView == VK_NULL_HANDLE && info.sampler == VK_NULL_HANDLE)
+				{
+					tds.bound_images.erase(slot);
+					tds.bound_opaque_descriptors.erase(slot);
+					continue;
+				}
 				image_access access { nullptr, info.imageLayout };
 				if (info.imageView != VK_NULL_HANDLE)
 				{
@@ -68,39 +74,52 @@ static void handle_VkWriteDescriptorSets(uint32_t descriptorWriteCount, const Vk
 					auto& image_data = VkImage_index.at(view_data.image_index);
 					access.image_data = &image_data;
 				}
-				tds.bound_images[binding] = access;
+				tds.bound_images[slot] = access;
+				tds.bound_opaque_descriptors.erase(slot);
 			}
 			break;
 		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
 		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
 			for (unsigned j = 0; j < pDescriptorWrites[i].descriptorCount; j++)
 			{
-				if (pDescriptorWrites[i].pBufferInfo[j].buffer == VK_NULL_HANDLE) continue;
+				const uint64_t slot = descriptor_binding_slot(binding, pDescriptorWrites[i].dstArrayElement + j);
+				if (pDescriptorWrites[i].pBufferInfo[j].buffer == VK_NULL_HANDLE)
+				{
+					tds.bound_buffers.erase(slot);
+					continue;
+				}
 				const uint32_t buffer_index = index_to_VkBuffer.index(pDescriptorWrites[i].pBufferInfo[j].buffer);
 				auto& buffer_data = VkBuffer_index.at(buffer_index);
 				VkDeviceSize size = pDescriptorWrites[i].pBufferInfo[j].range;
 				if (size == VK_WHOLE_SIZE) size = buffer_data.size - pDescriptorWrites[i].pBufferInfo[j].offset;
-				tds.bound_buffers[binding] = buffer_access { &buffer_data, pDescriptorWrites[i].pBufferInfo[j].offset, size };
+				tds.bound_buffers[slot] = buffer_access { &buffer_data, pDescriptorWrites[i].pBufferInfo[j].offset, size };
 			}
 			break;
 		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
 		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
 			for (unsigned j = 0; j < pDescriptorWrites[i].descriptorCount; j++)
 			{
-				tds.dynamic_buffers[binding] = pDescriptorWrites[i].pBufferInfo[j];
+				const uint64_t slot = descriptor_binding_slot(binding, pDescriptorWrites[i].dstArrayElement + j);
+				if (pDescriptorWrites[i].pBufferInfo[j].buffer == VK_NULL_HANDLE) tds.dynamic_buffers.erase(slot);
+				else tds.dynamic_buffers[slot] = pDescriptorWrites[i].pBufferInfo[j];
 			}
 			break;
 		case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
 		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
 			for (unsigned j = 0; j < pDescriptorWrites[i].descriptorCount; j++)
 			{
-				if (pDescriptorWrites[i].pTexelBufferView[j] == VK_NULL_HANDLE) continue;
+				const uint64_t slot = descriptor_binding_slot(binding, pDescriptorWrites[i].dstArrayElement + j);
+				if (pDescriptorWrites[i].pTexelBufferView[j] == VK_NULL_HANDLE)
+				{
+					tds.bound_buffers.erase(slot);
+					continue;
+				}
 				const uint32_t bufferview_index = index_to_VkBufferView.index(pDescriptorWrites[i].pTexelBufferView[j]);
 				auto& bufferview_data = VkBufferView_index.at(bufferview_index);
 				auto& buffer_data = VkBuffer_index.at(bufferview_data.buffer_index);
 				VkDeviceSize size = bufferview_data.range;
 				if (size == VK_WHOLE_SIZE) size = buffer_data.size - bufferview_data.offset;
-				tds.bound_buffers[binding] = buffer_access { &buffer_data, bufferview_data.offset, size };
+				tds.bound_buffers[slot] = buffer_access { &buffer_data, bufferview_data.offset, size };
 			}
 			break;
 		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK: // Provided by VK_VERSION_1_3
@@ -119,12 +138,17 @@ static void handle_VkWriteDescriptorSets(uint32_t descriptorWriteCount, const Vk
 				assert(ptr->accelerationStructureCount == pDescriptorWrites[i].descriptorCount);
 				for (unsigned j = 0; j < ptr->accelerationStructureCount; j++)
 				{
-					if (ptr->pAccelerationStructures[j] == VK_NULL_HANDLE) continue;
+					const uint64_t slot = descriptor_binding_slot(binding, pDescriptorWrites[i].dstArrayElement + j);
+					if (ptr->pAccelerationStructures[j] == VK_NULL_HANDLE)
+					{
+						tds.bound_opaque_descriptors.erase(slot);
+						continue;
+					}
 					const uint32_t as_index = index_to_VkAccelerationStructureKHR.index(ptr->pAccelerationStructures[j]);
 					auto& as_data = VkAccelerationStructureKHR_index.at(as_index);
 					uint64_t opaque_value = as_data.capture_device_address;
 					if (opaque_value == 0) opaque_value = (uint64_t)ptr->pAccelerationStructures[j];
-					tds.bound_opaque_descriptors[binding] = opaque_value;
+					tds.bound_opaque_descriptors[slot] = opaque_value;
 				}
 			}
 			break;
@@ -157,10 +181,27 @@ static void handle_VkCopyDescriptorSets(uint32_t descriptorCopyCount, const VkCo
 		auto& src = VkDescriptorSet_index.at(src_index);
 		const uint32_t dst_index = index_to_VkDescriptorSet.index(pDescriptorCopies[i].dstSet);
 		auto& dst = VkDescriptorSet_index.at(dst_index);
-		for (const auto& pair : src.bound_buffers) dst.bound_buffers[pair.first] = pair.second;
-		for (const auto& pair : src.bound_images) dst.bound_images[pair.first] = pair.second;
-		for (const auto& pair : src.bound_opaque_descriptors) dst.bound_opaque_descriptors[pair.first] = pair.second;
-		for (const auto& pair : src.dynamic_buffers) dst.dynamic_buffers[pair.first] = pair.second;
+		for (uint32_t j = 0; j < pDescriptorCopies[i].descriptorCount; j++)
+		{
+			const uint64_t src_slot = descriptor_binding_slot(pDescriptorCopies[i].srcBinding, pDescriptorCopies[i].srcArrayElement + j);
+			const uint64_t dst_slot = descriptor_binding_slot(pDescriptorCopies[i].dstBinding, pDescriptorCopies[i].dstArrayElement + j);
+
+			auto src_buffer = src.bound_buffers.find(src_slot);
+			if (src_buffer != src.bound_buffers.end()) dst.bound_buffers[dst_slot] = src_buffer->second;
+			else dst.bound_buffers.erase(dst_slot);
+
+			auto src_image = src.bound_images.find(src_slot);
+			if (src_image != src.bound_images.end()) dst.bound_images[dst_slot] = src_image->second;
+			else dst.bound_images.erase(dst_slot);
+
+			auto src_opaque = src.bound_opaque_descriptors.find(src_slot);
+			if (src_opaque != src.bound_opaque_descriptors.end()) dst.bound_opaque_descriptors[dst_slot] = src_opaque->second;
+			else dst.bound_opaque_descriptors.erase(dst_slot);
+
+			auto src_dynamic = src.dynamic_buffers.find(src_slot);
+			if (src_dynamic != src.dynamic_buffers.end()) dst.dynamic_buffers[dst_slot] = src_dynamic->second;
+			else dst.dynamic_buffers.erase(dst_slot);
+		}
 	}
 }
 
@@ -240,6 +281,7 @@ void postprocess_vkCreateDescriptorSetLayout(callback_context& cb, VkDevice devi
 	{
 		const VkDescriptorSetLayoutBinding& binding = pCreateInfo->pBindings[i];
 		layout_data.binding_types[binding.binding] = binding.descriptorType;
+		layout_data.binding_counts[binding.binding] = binding.descriptorCount;
 	}
 }
 

--- a/tests/command_execution_test.cpp
+++ b/tests/command_execution_test.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstdint>
 #include <deque>
+#include <initializer_list>
 #include <list>
 #include <vector>
 
@@ -192,6 +193,15 @@ static change_source make_source(uint32_t packet)
 static bool same_source(const change_source& a, const change_source& b)
 {
 	return a.packet == b.packet && a.frame == b.frame && a.thread == b.thread && a.call_id == b.call_id;
+}
+
+static void set_storage_buffer_binding(command_execution_data& data, uint32_t set, uint32_t binding, trackedbuffer* buffer_data,
+	VkDeviceSize offset, VkDeviceSize size)
+{
+	command_execution_data::simulator_binding& dst = data.descriptor_sets[set][binding];
+	dst.descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+	dst.buffers.resize(1);
+	dst.buffers[0] = { buffer_data, offset, size };
 }
 
 static void init_buffer(uint32_t index, VkDeviceSize size)
@@ -406,8 +416,8 @@ struct compute_shader_fixture
 		device_data.index = 0;
 		device_data.allocator = &allocator;
 
-		data.descriptorsets[0][0] = { &VkBuffer_index[0], 0, compute_shader_buffer_size };
-		data.descriptorsets[0][1] = { &VkBuffer_index[1], 0, compute_shader_buffer_size };
+		set_storage_buffer_binding(data, 0, 0, &VkBuffer_index[0], 0, compute_shader_buffer_size);
+		set_storage_buffer_binding(data, 0, 1, &VkBuffer_index[1], 0, compute_shader_buffer_size);
 	}
 
 	~compute_shader_fixture()
@@ -492,8 +502,8 @@ static void execute_compute_shader_copy_provenance()
 		.pending_descriptor_rewrites = pending_descriptor_rewrites,
 		.descriptor_buffer_payloads = descriptor_buffer_payloads,
 	};
-	data.descriptorsets[0][0] = { &VkBuffer_index[0], 0, buffer_size };
-	data.descriptorsets[0][1] = { &VkBuffer_index[1], 0, buffer_size };
+	set_storage_buffer_binding(data, 0, 0, &VkBuffer_index[0], 0, buffer_size);
+	set_storage_buffer_binding(data, 0, 1, &VkBuffer_index[1], 0, buffer_size);
 
 	assert(execute_commands(data));
 	assert(load_u32(output, 0) == first_value);
@@ -576,7 +586,7 @@ static void execute_compute_shader_bda_unbound_input()
 		.pending_descriptor_rewrites = pending_descriptor_rewrites,
 		.descriptor_buffer_payloads = descriptor_buffer_payloads,
 	};
-	data.descriptorsets[0][0] = { &VkBuffer_index[1], 0, output_buffer_size };
+	set_storage_buffer_binding(data, 0, 0, &VkBuffer_index[1], 0, output_buffer_size);
 
 	assert(!VkBuffer_index[0].is_state(trackedobject::states::bound));
 	assert(execute_commands(data));
@@ -646,10 +656,10 @@ static void execute_compute_shader_bda_copied_address_chain()
 
 	VkDescriptorSet_index.clear();
 	VkDescriptorSet_index.resize(2);
-	VkDescriptorSet_index[0].bound_buffers[0] = { &VkBuffer_index[0], 0, address_buffer_size };
-	VkDescriptorSet_index[0].bound_buffers[1] = { &VkBuffer_index[1], 0, address_buffer_size };
-	VkDescriptorSet_index[1].bound_buffers[0] = { &VkBuffer_index[1], 0, address_buffer_size };
-	VkDescriptorSet_index[1].bound_buffers[1] = { &VkBuffer_index[2], 0, output_buffer_size };
+	VkDescriptorSet_index[0].bound_buffers[descriptor_binding_slot(0, 0)] = { &VkBuffer_index[0], 0, address_buffer_size };
+	VkDescriptorSet_index[0].bound_buffers[descriptor_binding_slot(1, 0)] = { &VkBuffer_index[1], 0, address_buffer_size };
+	VkDescriptorSet_index[1].bound_buffers[descriptor_binding_slot(0, 0)] = { &VkBuffer_index[1], 0, address_buffer_size };
+	VkDescriptorSet_index[1].bound_buffers[descriptor_binding_slot(1, 0)] = { &VkBuffer_index[2], 0, output_buffer_size };
 
 	VkPipeline_index.clear();
 	const uint32_t copy_pipeline_index = add_compute_pipeline(4, plain_copy_shader_code());
@@ -780,8 +790,8 @@ static void execute_compute_shader_bda_two_lane_output_provenance()
 
 	VkDescriptorSet_index.clear();
 	VkDescriptorSet_index.resize(1);
-	VkDescriptorSet_index[0].bound_buffers[0] = { &VkBuffer_index[0], 0, address_buffer_size };
-	VkDescriptorSet_index[0].bound_buffers[1] = { &VkBuffer_index[1], 0, color_buffer_size };
+	VkDescriptorSet_index[0].bound_buffers[descriptor_binding_slot(0, 0)] = { &VkBuffer_index[0], 0, address_buffer_size };
+	VkDescriptorSet_index[0].bound_buffers[descriptor_binding_slot(1, 0)] = { &VkBuffer_index[1], 0, color_buffer_size };
 
 	init_compute_pipeline(6, bda_two_store_shader_code());
 
@@ -933,9 +943,9 @@ static void execute_compute_shader_bda_interleave_copied_address_provenance()
 		.pending_descriptor_rewrites = pending_descriptor_rewrites,
 		.descriptor_buffer_payloads = descriptor_buffer_payloads,
 	};
-	interleave_data.descriptorsets[0][0] = { &VkBuffer_index[0], 0, address_buffer_size };
-	interleave_data.descriptorsets[0][1] = { &VkBuffer_index[1], 0, color_buffer_size };
-	interleave_data.descriptorsets[0][2] = { &VkBuffer_index[2], 0, interleave_buffer_size };
+	set_storage_buffer_binding(interleave_data, 0, 0, &VkBuffer_index[0], 0, address_buffer_size);
+	set_storage_buffer_binding(interleave_data, 0, 1, &VkBuffer_index[1], 0, color_buffer_size);
+	set_storage_buffer_binding(interleave_data, 0, 2, &VkBuffer_index[2], 0, interleave_buffer_size);
 
 	assert(execute_commands(interleave_data));
 	assert(load_u32(interleave_buffer, 0) == color0_lo);
@@ -977,7 +987,7 @@ static void execute_compute_shader_bda_interleave_copied_address_provenance()
 		.pending_descriptor_rewrites = pending_descriptor_rewrites,
 		.descriptor_buffer_payloads = descriptor_buffer_payloads,
 	};
-	output_data.descriptorsets[0][0] = { &VkBuffer_index[2], 0, interleave_buffer_size };
+	set_storage_buffer_binding(output_data, 0, 0, &VkBuffer_index[2], 0, interleave_buffer_size);
 
 	assert(execute_commands(output_data));
 	assert(load_u32(output_buffer, 0) == color0_lo);


### PR DESCRIPTION
Implement descriptor arrays as arrays of pointers for SSBO and UBO only. This is to achieve analogous behaviour between gfxreconstruct and lavatube.